### PR TITLE
Add clang-format and reformat source code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 100
+SortIncludes: false

--- a/src/output_behavior_generic.c
+++ b/src/output_behavior_generic.c
@@ -58,9 +58,7 @@ static void ob_geenric_set_output_value(struct output_behavior_geenric_data *dat
         return;
     }
 
-    uint32_t value = data->active
-        ? data->is_momentum ? data->momentum_force : data->force
-        : 0;
+    uint32_t value = data->active ? data->is_momentum ? data->momentum_force : data->force : 0;
 
     // LOG_DBG("set_value: %d", value);
     api->set_value(output_dev, value);
@@ -69,9 +67,8 @@ static void ob_geenric_set_output_value(struct output_behavior_geenric_data *dat
 
 static void ob_generic_deactivate_cb(struct k_work *work) {
     struct k_work_delayable *work_delayable = (struct k_work_delayable *)work;
-    struct output_behavior_geenric_data *data = CONTAINER_OF(work_delayable, 
-                                                             struct output_behavior_geenric_data,
-                                                             deactivate_work);
+    struct output_behavior_geenric_data *data =
+        CONTAINER_OF(work_delayable, struct output_behavior_geenric_data, deactivate_work);
     const struct output_behavior_geenric_config *cfg = data->dev->config;
 
     if (!data->active && cfg->time_to_live_ms) {
@@ -85,21 +82,20 @@ static void ob_generic_deactivate_cb(struct k_work *work) {
 
 static void ob_generic_activate_cb(struct k_work *work) {
     struct k_work_delayable *work_delayable = (struct k_work_delayable *)work;
-    struct output_behavior_geenric_data *data = CONTAINER_OF(work_delayable, 
-                                                             struct output_behavior_geenric_data,
-                                                             activate_work);
+    struct output_behavior_geenric_data *data =
+        CONTAINER_OF(work_delayable, struct output_behavior_geenric_data, activate_work);
     const struct output_behavior_geenric_config *cfg = data->dev->config;
 
     if (data->active && cfg->time_to_live_ms) {
         return;
     }
-    
+
     if (!data->active) {
         LOG_DBG("actvate");
         data->active = true;
         ob_geenric_set_output_value(data);
     }
-    
+
     if (cfg->toggle) {
         return;
     }
@@ -141,7 +137,8 @@ static int ob_generic_binding_pressed(struct zmk_behavior_binding *binding,
     }
 
     if (cfg->toggle) {
-        struct k_work_delayable *work = data->active ? &data->deactivate_work : &data->activate_work;
+        struct k_work_delayable *work =
+            data->active ? &data->deactivate_work : &data->activate_work;
         k_work_schedule(work, K_MSEC(cfg->delay));
     } else {
         k_work_schedule(&data->activate_work, K_MSEC(cfg->delay));
@@ -170,23 +167,21 @@ static const struct behavior_driver_api output_behavior_geenric_driver_api = {
 
 #define ZMK_OUTPUT_INIT_PRIORITY 92
 
-#define KP_INST(n)                                                                         \
-    static struct output_behavior_geenric_data output_behavior_geenric_data_##n = {};      \
-    static struct output_behavior_geenric_config output_behavior_geenric_config_##n = {    \
-        .output_dev = DEVICE_DT_GET(DT_INST_PHANDLE(n, device)),                           \
-        .delay = DT_INST_PROP(n, delay),                                                   \
-        .time_to_live_ms = DT_INST_PROP(n, time_to_live_ms),                               \
-        .toggle = DT_INST_PROP(n, toggle),                                                 \
-        .force = DT_INST_PROP(n, force),                                                   \
-        .momentum = DT_INST_PROP(n, momentum),                                             \
-        .momentum_force = DT_INST_PROP(n, momentum_force),                                 \
-        .positional = DT_INST_PROP(n, positional),                                         \
-    };                                                                                     \
-    BEHAVIOR_DT_INST_DEFINE(n, output_behavior_to_init, NULL,                              \
-                            &output_behavior_geenric_data_##n,                             \
-                            &output_behavior_geenric_config_##n,                           \
-                            POST_KERNEL, ZMK_OUTPUT_INIT_PRIORITY,                         \
-                            &output_behavior_geenric_driver_api);
+#define KP_INST(n)                                                                                 \
+    static struct output_behavior_geenric_data output_behavior_geenric_data_##n = {};              \
+    static struct output_behavior_geenric_config output_behavior_geenric_config_##n = {            \
+        .output_dev = DEVICE_DT_GET(DT_INST_PHANDLE(n, device)),                                   \
+        .delay = DT_INST_PROP(n, delay),                                                           \
+        .time_to_live_ms = DT_INST_PROP(n, time_to_live_ms),                                       \
+        .toggle = DT_INST_PROP(n, toggle),                                                         \
+        .force = DT_INST_PROP(n, force),                                                           \
+        .momentum = DT_INST_PROP(n, momentum),                                                     \
+        .momentum_force = DT_INST_PROP(n, momentum_force),                                         \
+        .positional = DT_INST_PROP(n, positional),                                                 \
+    };                                                                                             \
+    BEHAVIOR_DT_INST_DEFINE(n, output_behavior_to_init, NULL, &output_behavior_geenric_data_##n,   \
+                            &output_behavior_geenric_config_##n, POST_KERNEL,                      \
+                            ZMK_OUTPUT_INIT_PRIORITY, &output_behavior_geenric_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(KP_INST)
 

--- a/src/output_generic.c
+++ b/src/output_generic.c
@@ -75,19 +75,16 @@ static const struct output_generic_api api = {
 
 #define ZMK_OUTPUT_INIT_PRIORITY 91
 
-#define OG_INST(n)                                                             \
-    static struct output_generic_data data_##n = { .busy = false, };           \
-    static const struct output_generic_config config_##n = {                   \
-        .has_control = COND_CODE_1(                                            \
-                        DT_INST_NODE_HAS_PROP(n, control_gpios),               \
-                        (true), (false)),                                      \
-        .control = COND_CODE_1(                                                \
-                    DT_INST_NODE_HAS_PROP(n, control_gpios),                   \
-                    (GPIO_DT_SPEC_INST_GET(n, control_gpios)),                 \
-                    (NULL)),                                                   \
-    };                                                                         \
-    DEVICE_DT_INST_DEFINE(0, output_generic_init, DEVICE_DT_INST_GET(n),       \
-                          &data_##n, &config_##n,                              \
+#define OG_INST(n)                                                                                 \
+    static struct output_generic_data data_##n = {                                                 \
+        .busy = false,                                                                             \
+    };                                                                                             \
+    static const struct output_generic_config config_##n = {                                       \
+        .has_control = COND_CODE_1(DT_INST_NODE_HAS_PROP(n, control_gpios), (true), (false)),      \
+        .control = COND_CODE_1(DT_INST_NODE_HAS_PROP(n, control_gpios),                            \
+                               (GPIO_DT_SPEC_INST_GET(n, control_gpios)), (NULL)),                 \
+    };                                                                                             \
+    DEVICE_DT_INST_DEFINE(0, output_generic_init, DEVICE_DT_INST_GET(n), &data_##n, &config_##n,   \
                           POST_KERNEL, ZMK_OUTPUT_INIT_PRIORITY, &api);
 
 DT_INST_FOREACH_STATUS_OKAY(OG_INST)

--- a/src/output_haptic_feedback.c
+++ b/src/output_haptic_feedback.c
@@ -38,19 +38,19 @@ static int output_haptic_feedback_set_value(const struct device *dev, uint8_t va
         return -EBUSY;
     }
     data->busy = true;
-    
+
     int rc = 0;
 
 #if IS_ENABLED(CONFIG_DRV2605)
     if (config->fb_drv == OUTPUT_HAPTIC_FEEDBACK_DRIVER_DRV2605) {
         int err = 0;
-    	struct sensor_value val = { .val1 = 0, .val2 = 0 };
+        struct sensor_value val = {.val1 = 0, .val2 = 0};
 
         if (value) {
-            val.val1 = 0; // slot 0
+            val.val1 = 0;     // slot 0
             val.val2 = value; // waveformm
-            err = sensor_attr_set(fb_dev, SENSOR_CHAN_ALL, 
-                                (enum sensor_attribute) DRV2605_ATTR_WAVEFORM, &val);
+            err = sensor_attr_set(fb_dev, SENSOR_CHAN_ALL,
+                                  (enum sensor_attribute)DRV2605_ATTR_WAVEFORM, &val);
             if (err) {
                 LOG_WRN("Fail to sensor_attr_set DRV2605_ATTR_WAVEFORM");
                 rc = -EIO;
@@ -60,24 +60,23 @@ static int output_haptic_feedback_set_value(const struct device *dev, uint8_t va
             val.val1 = 1; // slot 1
             val.val2 = 0; // waveformm - empty
             err = sensor_attr_set(fb_dev, SENSOR_CHAN_ALL,
-                                (enum sensor_attribute) DRV2605_ATTR_WAVEFORM, &val);
+                                  (enum sensor_attribute)DRV2605_ATTR_WAVEFORM, &val);
             if (err) {
                 LOG_WRN("Fail to sensor_attr_set DRV2605_ATTR_WAVEFORM");
                 rc = -EIO;
                 goto exit;
             }
 
-            err = sensor_attr_set(fb_dev, SENSOR_CHAN_ALL,
-                                (enum sensor_attribute) DRV2605_ATTR_GO, &val);
+            err = sensor_attr_set(fb_dev, SENSOR_CHAN_ALL, (enum sensor_attribute)DRV2605_ATTR_GO,
+                                  &val);
             if (err) {
                 LOG_WRN("Fail to sensor_attr_set DRV2605_ATTR_GO");
                 rc = -EIO;
                 goto exit;
             }
-        }
-        else {
-            err = sensor_attr_set(fb_dev, SENSOR_CHAN_ALL, 
-                                (enum sensor_attribute) DRV2605_ATTR_WAVEFORM, &val);
+        } else {
+            err = sensor_attr_set(fb_dev, SENSOR_CHAN_ALL,
+                                  (enum sensor_attribute)DRV2605_ATTR_WAVEFORM, &val);
             if (err) {
                 LOG_WRN("Fail to sensor_attr_set DRV2605_ATTR_WAVEFORM");
                 rc = -EIO;
@@ -111,19 +110,17 @@ static const struct output_generic_api api = {
 
 #define ZMK_OUTPUT_INIT_PRIORITY 91
 
-#define OHFB_INST(n)                                                             \
-    static struct output_haptic_feedback_data data_##n = { .busy = false, };     \
-    static const struct output_haptic_feedback_config config_##n = {             \
-        .fb_drv = DT_INST_ENUM_IDX_OR(0, driver,                                 \
-                                      OUTPUT_HAPTIC_FEEDBACK_DRIVER_DRV2605),    \
-        .fb_dev = COND_CODE_1(                                                   \
-                    DT_INST_NODE_HAS_PROP(n, device),                            \
-                    (DEVICE_DT_GET(DT_INST_PHANDLE(n, device))),                 \
-                    (NULL)),                                                     \
-    };                                                                           \
-    DEVICE_DT_INST_DEFINE(0, output_haptic_feedback_init, DEVICE_DT_INST_GET(n), \
-                          &data_##n, &config_##n,                                \
-                          POST_KERNEL, ZMK_OUTPUT_INIT_PRIORITY, &api);
+#define OHFB_INST(n)                                                                               \
+    static struct output_haptic_feedback_data data_##n = {                                         \
+        .busy = false,                                                                             \
+    };                                                                                             \
+    static const struct output_haptic_feedback_config config_##n = {                               \
+        .fb_drv = DT_INST_ENUM_IDX_OR(0, driver, OUTPUT_HAPTIC_FEEDBACK_DRIVER_DRV2605),           \
+        .fb_dev = COND_CODE_1(DT_INST_NODE_HAS_PROP(n, device),                                    \
+                              (DEVICE_DT_GET(DT_INST_PHANDLE(n, device))), (NULL)),                \
+    };                                                                                             \
+    DEVICE_DT_INST_DEFINE(0, output_haptic_feedback_init, DEVICE_DT_INST_GET(n), &data_##n,        \
+                          &config_##n, POST_KERNEL, ZMK_OUTPUT_INIT_PRIORITY, &api);
 
 DT_INST_FOREACH_STATUS_OKAY(OHFB_INST)
 

--- a/src/output_motorized_fader.c
+++ b/src/output_motorized_fader.c
@@ -62,7 +62,7 @@ static int output_motorized_fader_set_value(const struct device *dev, uint8_t va
     //     goto exit;
     // }
 
-    struct sensor_value val = { .val1 = 0, .val2 = 0 };
+    struct sensor_value val = {.val1 = 0, .val2 = 0};
     err = sensor_channel_get(sensor_dev, SENSOR_CHAN_ALL, &val);
     if (err) {
         LOG_WRN("Failed to get channel from device %d", err);
@@ -76,8 +76,8 @@ static int output_motorized_fader_set_value(const struct device *dev, uint8_t va
     LOG_WRN("fader sen_val: %d", sen_val);
 
     val.val1 = 0;
-    err = sensor_attr_set(sensor_dev, SENSOR_CHAN_ALL, 
-                        (enum sensor_attribute) ANALOG_INPUT_ATTR_ACTIVE, &val);
+    err = sensor_attr_set(sensor_dev, SENSOR_CHAN_ALL,
+                          (enum sensor_attribute)ANALOG_INPUT_ATTR_ACTIVE, &val);
     if (err) {
         LOG_WRN("Fail to sensor_attr_set ANALOG_INPUT_ATTR_ACTIVE");
         rc = -EIO;
@@ -86,7 +86,7 @@ static int output_motorized_fader_set_value(const struct device *dev, uint8_t va
 
 #if IS_ENABLED(CONFIG_TB6612FNG)
     if (config->motor_drv == OUTPUT_MOTORIZED_FADER_DRIVER_TB6612FNG) {
-    	struct sensor_value val = { .val1 = 0, .val2 = 0 };
+        struct sensor_value val = {.val1 = 0, .val2 = 0};
 
         const struct device *tb6612fng_dev = motor_dev;
 
@@ -101,8 +101,7 @@ static int output_motorized_fader_set_value(const struct device *dev, uint8_t va
         if (value > sen_val) {
             // vel = -(value - sen_val);
             vel = -vec;
-        }
-        else if (value < sen_val) {
+        } else if (value < sen_val) {
             // vel = (sen_val - value);
             vel = vec;
         }
@@ -112,8 +111,8 @@ static int output_motorized_fader_set_value(const struct device *dev, uint8_t va
             // enable enable pin, disable iif vel == 0
             val.val1 = (!vel) ? 0 : 1;
             val.val2 = 0;
-            err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL, 
-                                (enum sensor_attribute) TB6612FNG_ATTR_ENABLE, &val);
+            err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL,
+                                  (enum sensor_attribute)TB6612FNG_ATTR_ENABLE, &val);
             if (err) {
                 LOG_WRN("Fail to sensor_attr_set TB6612FNG_ATTR_ENABLE");
             }
@@ -121,8 +120,8 @@ static int output_motorized_fader_set_value(const struct device *dev, uint8_t va
             // set velocity and inversr flag
             val.val1 = abs(vel);
             val.val2 = vel < 0;
-            err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL, 
-                                (enum sensor_attribute) TB6612FNG_ATTR_VELOCITY, &val);
+            err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL,
+                                  (enum sensor_attribute)TB6612FNG_ATTR_VELOCITY, &val);
             if (err) {
                 LOG_WRN("Fail to sensor_attr_set TB6612FNG_ATTR_VELOCITY");
             }
@@ -130,13 +129,12 @@ static int output_motorized_fader_set_value(const struct device *dev, uint8_t va
             // call sync to latch velocity setting to driver
             val.val1 = chan;
             val.val2 = 0;
-            err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL, 
-                                (enum sensor_attribute) TB6612FNG_ATTR_SYNC, &val);
+            err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL,
+                                  (enum sensor_attribute)TB6612FNG_ATTR_SYNC, &val);
             if (err) {
                 LOG_WRN("Fail to sensor_attr_set TB6612FNG_ATTR_SYNC");
             }
         }
-    
 
         while (true) {
             k_msleep(3);
@@ -168,8 +166,7 @@ static int output_motorized_fader_set_value(const struct device *dev, uint8_t va
             if (value > sen_val) {
                 // vel2 = -(value - sen_val);
                 vel2 = -abs(vel);
-            }
-            else if (value < sen_val) {
+            } else if (value < sen_val) {
                 // vel2 = (sen_val - value);
                 vel2 = abs(vel);
             }
@@ -181,8 +178,8 @@ static int output_motorized_fader_set_value(const struct device *dev, uint8_t va
                 // enable enable pin, disable iif vel == 0
                 val.val1 = (!vel) ? 0 : 1;
                 val.val2 = 0;
-                err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL, 
-                                    (enum sensor_attribute) TB6612FNG_ATTR_ENABLE, &val);
+                err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL,
+                                      (enum sensor_attribute)TB6612FNG_ATTR_ENABLE, &val);
                 if (err) {
                     LOG_WRN("Fail to sensor_attr_set TB6612FNG_ATTR_ENABLE");
                 }
@@ -190,8 +187,8 @@ static int output_motorized_fader_set_value(const struct device *dev, uint8_t va
                 // set velocity and inversr flag
                 val.val1 = abs(vel);
                 val.val2 = vel < 0;
-                err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL, 
-                                    (enum sensor_attribute) TB6612FNG_ATTR_VELOCITY, &val);
+                err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL,
+                                      (enum sensor_attribute)TB6612FNG_ATTR_VELOCITY, &val);
                 if (err) {
                     LOG_WRN("Fail to sensor_attr_set TB6612FNG_ATTR_VELOCITY");
                 }
@@ -199,32 +196,30 @@ static int output_motorized_fader_set_value(const struct device *dev, uint8_t va
                 // call sync to latch velocity setting to driver
                 val.val1 = chan;
                 val.val2 = 0;
-                err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL, 
-                                    (enum sensor_attribute) TB6612FNG_ATTR_SYNC, &val);
+                err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL,
+                                      (enum sensor_attribute)TB6612FNG_ATTR_SYNC, &val);
                 if (err) {
                     LOG_WRN("Fail to sensor_attr_set TB6612FNG_ATTR_SYNC");
                 }
             }
-
         }
 
         // disable
         val.val1 = 0;
         val.val2 = 0;
-        err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL, 
-                            (enum sensor_attribute) TB6612FNG_ATTR_ENABLE, &val);
+        err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL,
+                              (enum sensor_attribute)TB6612FNG_ATTR_ENABLE, &val);
         if (err) {
             LOG_WRN("Fail to sensor_attr_set TB6612FNG_ATTR_ENABLE");
             rc = -EIO;
             goto exit;
         }
-
     }
 #endif /* IS_ENABLED(CONFIG_TB6612FNG) */
 
 #if IS_ENABLED(CONFIG_DRV883X)
     if (config->motor_drv == OUTPUT_MOTORIZED_FADER_DRIVER_DRV883X) {
-    	struct sensor_value val = { .val1 = 0, .val2 = 0 };
+        struct sensor_value val = {.val1 = 0, .val2 = 0};
 
         const struct device *tb6612fng_dev = motor_dev;
 
@@ -239,8 +234,7 @@ static int output_motorized_fader_set_value(const struct device *dev, uint8_t va
         if (value > sen_val) {
             // vel = -(value - sen_val);
             vel = -vec;
-        }
-        else if (value < sen_val) {
+        } else if (value < sen_val) {
             // vel = (sen_val - value);
             vel = vec;
         }
@@ -250,8 +244,8 @@ static int output_motorized_fader_set_value(const struct device *dev, uint8_t va
             // enable enable pin, disable iif vel == 0
             val.val1 = (!vel) ? 0 : 1;
             val.val2 = 0;
-            err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL, 
-                                (enum sensor_attribute) DRV883X_ATTR_ENABLE, &val);
+            err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL,
+                                  (enum sensor_attribute)DRV883X_ATTR_ENABLE, &val);
             if (err) {
                 LOG_WRN("Fail to sensor_attr_set DRV883X_ATTR_ENABLE");
             }
@@ -259,8 +253,8 @@ static int output_motorized_fader_set_value(const struct device *dev, uint8_t va
             // set velocity and inversr flag
             val.val1 = abs(vel);
             val.val2 = vel < 0;
-            err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL, 
-                                (enum sensor_attribute) DRV883X_ATTR_VELOCITY, &val);
+            err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL,
+                                  (enum sensor_attribute)DRV883X_ATTR_VELOCITY, &val);
             if (err) {
                 LOG_WRN("Fail to sensor_attr_set DRV883X_ATTR_VELOCITY");
             }
@@ -268,13 +262,12 @@ static int output_motorized_fader_set_value(const struct device *dev, uint8_t va
             // call sync to latch velocity setting to driver
             val.val1 = chan;
             val.val2 = 0;
-            err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL, 
-                                (enum sensor_attribute) DRV883X_ATTR_SYNC, &val);
+            err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL,
+                                  (enum sensor_attribute)DRV883X_ATTR_SYNC, &val);
             if (err) {
                 LOG_WRN("Fail to sensor_attr_set DRV883X_ATTR_SYNC");
             }
         }
-    
 
         while (true) {
             k_msleep(3);
@@ -306,8 +299,7 @@ static int output_motorized_fader_set_value(const struct device *dev, uint8_t va
             if (value > sen_val) {
                 // vel2 = -(value - sen_val);
                 vel2 = -abs(vel);
-            }
-            else if (value < sen_val) {
+            } else if (value < sen_val) {
                 // vel2 = (sen_val - value);
                 vel2 = abs(vel);
             }
@@ -319,8 +311,8 @@ static int output_motorized_fader_set_value(const struct device *dev, uint8_t va
                 // enable enable pin, disable iif vel == 0
                 val.val1 = (!vel) ? 0 : 1;
                 val.val2 = 0;
-                err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL, 
-                                    (enum sensor_attribute) DRV883X_ATTR_ENABLE, &val);
+                err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL,
+                                      (enum sensor_attribute)DRV883X_ATTR_ENABLE, &val);
                 if (err) {
                     LOG_WRN("Fail to sensor_attr_set DRV883X_ATTR_ENABLE");
                 }
@@ -328,8 +320,8 @@ static int output_motorized_fader_set_value(const struct device *dev, uint8_t va
                 // set velocity and inversr flag
                 val.val1 = abs(vel);
                 val.val2 = vel < 0;
-                err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL, 
-                                    (enum sensor_attribute) DRV883X_ATTR_VELOCITY, &val);
+                err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL,
+                                      (enum sensor_attribute)DRV883X_ATTR_VELOCITY, &val);
                 if (err) {
                     LOG_WRN("Fail to sensor_attr_set DRV883X_ATTR_VELOCITY");
                 }
@@ -337,32 +329,30 @@ static int output_motorized_fader_set_value(const struct device *dev, uint8_t va
                 // call sync to latch velocity setting to driver
                 val.val1 = chan;
                 val.val2 = 0;
-                err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL, 
-                                    (enum sensor_attribute) DRV883X_ATTR_SYNC, &val);
+                err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL,
+                                      (enum sensor_attribute)DRV883X_ATTR_SYNC, &val);
                 if (err) {
                     LOG_WRN("Fail to sensor_attr_set DRV883X_ATTR_SYNC");
                 }
             }
-
         }
 
         // disable
         val.val1 = 0;
         val.val2 = 0;
-        err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL, 
-                            (enum sensor_attribute) DRV883X_ATTR_ENABLE, &val);
+        err = sensor_attr_set(tb6612fng_dev, SENSOR_CHAN_ALL,
+                              (enum sensor_attribute)DRV883X_ATTR_ENABLE, &val);
         if (err) {
             LOG_WRN("Fail to sensor_attr_set DRV883X_ATTR_ENABLE");
             rc = -EIO;
             goto exit;
         }
-
     }
 #endif /* IS_ENABLED(CONFIG_DRV883X) */
 
     val.val1 = 1;
-    err = sensor_attr_set(sensor_dev, SENSOR_CHAN_ALL, 
-                        (enum sensor_attribute) ANALOG_INPUT_ATTR_ACTIVE, &val);
+    err = sensor_attr_set(sensor_dev, SENSOR_CHAN_ALL,
+                          (enum sensor_attribute)ANALOG_INPUT_ATTR_ACTIVE, &val);
     if (err) {
         LOG_WRN("Fail to sensor_attr_set ANALOG_INPUT_ATTR_ACTIVE");
         rc = -EIO;
@@ -393,28 +383,26 @@ static const struct output_generic_api api = {
 
 #define ZMK_OUTPUT_INIT_PRIORITY 91
 
-#define OHFB_INST(n)                                                                \
-    static struct output_motorized_fader_data data_##n = { .busy = false, };        \
-    static const struct output_motorized_fader_config config_##n = {                \
-        .sensor_dev = COND_CODE_1(                                                  \
-                        DT_INST_NODE_HAS_PROP(n, sensor_device),                    \
-                        (DEVICE_DT_GET(DT_INST_PHANDLE(n, sensor_device))),         \
-                        (NULL)),                                                    \
-        .sensor_channel = DT_INST_PROP(n, sensor_channel),                          \
-        .motor_dev = COND_CODE_1(                                                   \
-                        DT_INST_NODE_HAS_PROP(n, motor_driver_device),              \
-                        (DEVICE_DT_GET(DT_INST_PHANDLE(n, motor_driver_device))),   \
-                        (NULL)),                                                    \
-        .motor_drv = DT_INST_ENUM_IDX_OR(0, motor_driver,                           \
-                                         OUTPUT_MOTORIZED_FADER_DRIVER_TB6612FNG),  \
-        .motor_channel = DT_INST_PROP(n, motor_channel),                            \
-        .proportional = DT_INST_PROP(n, proportional),                              \
-        .integral = DT_INST_PROP(n, integral),                                      \
-        .derivative = DT_INST_PROP(n, derivative),                                  \
-    };                                                                              \
-    DEVICE_DT_INST_DEFINE(0, output_motorized_fader_init, DEVICE_DT_INST_GET(n),    \
-                          &data_##n, &config_##n,                                   \
-                          POST_KERNEL, ZMK_OUTPUT_INIT_PRIORITY, &api);
+#define OHFB_INST(n)                                                                               \
+    static struct output_motorized_fader_data data_##n = {                                         \
+        .busy = false,                                                                             \
+    };                                                                                             \
+    static const struct output_motorized_fader_config config_##n = {                               \
+        .sensor_dev = COND_CODE_1(DT_INST_NODE_HAS_PROP(n, sensor_device),                         \
+                                  (DEVICE_DT_GET(DT_INST_PHANDLE(n, sensor_device))), (NULL)),     \
+        .sensor_channel = DT_INST_PROP(n, sensor_channel),                                         \
+        .motor_dev =                                                                               \
+            COND_CODE_1(DT_INST_NODE_HAS_PROP(n, motor_driver_device),                             \
+                        (DEVICE_DT_GET(DT_INST_PHANDLE(n, motor_driver_device))), (NULL)),         \
+        .motor_drv =                                                                               \
+            DT_INST_ENUM_IDX_OR(0, motor_driver, OUTPUT_MOTORIZED_FADER_DRIVER_TB6612FNG),         \
+        .motor_channel = DT_INST_PROP(n, motor_channel),                                           \
+        .proportional = DT_INST_PROP(n, proportional),                                             \
+        .integral = DT_INST_PROP(n, integral),                                                     \
+        .derivative = DT_INST_PROP(n, derivative),                                                 \
+    };                                                                                             \
+    DEVICE_DT_INST_DEFINE(0, output_motorized_fader_init, DEVICE_DT_INST_GET(n), &data_##n,        \
+                          &config_##n, POST_KERNEL, ZMK_OUTPUT_INIT_PRIORITY, &api);
 
 DT_INST_FOREACH_STATUS_OKAY(OHFB_INST)
 

--- a/src/output_pwm.c
+++ b/src/output_pwm.c
@@ -35,7 +35,7 @@ static int output_pwm_set_value(const struct device *dev, uint8_t value) {
         return -EBUSY;
     }
     data->busy = true;
-    
+
     int rc = 0;
 
     uint32_t period = pwm.period;
@@ -43,8 +43,7 @@ static int output_pwm_set_value(const struct device *dev, uint8_t value) {
         uint32_t pulse = period / 256.0 * value;
         LOG_DBG("enable: force %d period %d pulse %d", value, period, pulse);
         pwm_set_dt(&pwm, period, pulse);
-    }
-    else {
+    } else {
         pwm_set_dt(&pwm, period, 0);
     }
 
@@ -72,13 +71,14 @@ static const struct output_generic_api api = {
 
 #define ZMK_OUTPUT_INIT_PRIORITY 91
 
-#define OPWM_INST(n)                                                             \
-    static struct output_pwm_data data_##n = { .busy = false, };                 \
-    static const struct output_pwm_config config_##n = {                         \
-        .pwm = PWM_DT_SPEC_GET(DT_DRV_INST(n)),                                  \
-    };                                                                           \
-    DEVICE_DT_INST_DEFINE(0, output_pwm_init, DEVICE_DT_INST_GET(n),             \
-                          &data_##n, &config_##n,                                \
+#define OPWM_INST(n)                                                                               \
+    static struct output_pwm_data data_##n = {                                                     \
+        .busy = false,                                                                             \
+    };                                                                                             \
+    static const struct output_pwm_config config_##n = {                                           \
+        .pwm = PWM_DT_SPEC_GET(DT_DRV_INST(n)),                                                    \
+    };                                                                                             \
+    DEVICE_DT_INST_DEFINE(0, output_pwm_init, DEVICE_DT_INST_GET(n), &data_##n, &config_##n,       \
                           POST_KERNEL, ZMK_OUTPUT_INIT_PRIORITY, &api);
 
 DT_INST_FOREACH_STATUS_OKAY(OPWM_INST)

--- a/src/output_split_output_relay.c
+++ b/src/output_split_output_relay.c
@@ -36,7 +36,7 @@ static int output_split_output_relay_set_value(const struct device *dev, uint8_t
     int rc = 0;
 
 #if IS_ENABLED(CONFIG_ZMK_SPLT_PERIPHERAL_OUTPUT_RELAY)
-    struct zmk_split_bt_output_relay_event ev = { .value = value };
+    struct zmk_split_bt_output_relay_event ev = {.value = value};
     zmk_split_bt_invoke_output(dev, ev);
 #endif /* IS_ENABLED(CONFIG_ZMK_SPLT_PERIPHERAL_OUTPUT_RELAY) */
 
@@ -64,13 +64,13 @@ static const struct output_generic_api api = {
 
 #define ZMK_OUTPUT_INIT_PRIORITY 91
 
-#define OSOR_INST(n)                                                                        \
-    static struct output_split_output_relay_data data_##n = { .busy = false, };             \
-    static const struct output_split_output_relay_config config_##n = {                     \
-    };                                                                                      \
-    DEVICE_DT_INST_DEFINE(0, output_split_output_relay_init, DEVICE_DT_INST_GET(n),         \
-                          &data_##n, &config_##n,                                           \
-                          POST_KERNEL, ZMK_OUTPUT_INIT_PRIORITY, &api);
+#define OSOR_INST(n)                                                                               \
+    static struct output_split_output_relay_data data_##n = {                                      \
+        .busy = false,                                                                             \
+    };                                                                                             \
+    static const struct output_split_output_relay_config config_##n = {};                          \
+    DEVICE_DT_INST_DEFINE(0, output_split_output_relay_init, DEVICE_DT_INST_GET(n), &data_##n,     \
+                          &config_##n, POST_KERNEL, ZMK_OUTPUT_INIT_PRIORITY, &api);
 
 DT_INST_FOREACH_STATUS_OKAY(OSOR_INST)
 


### PR DESCRIPTION
I don’t want to be the formatting police, but it would be great to have a unified set of clang-format rules (similar to what ZMK uses) to make pull requests simpler. It’s not clear what rules you’re currently using, if any. Feel free to close this issue and provide your own set of rules if you prefer.